### PR TITLE
Fix startup script

### DIFF
--- a/code/pyqgis/startup.py
+++ b/code/pyqgis/startup.py
@@ -7,5 +7,5 @@ def customize():
 	iface.mainWindow().setWindowTitle(f'{title} | {version}')
 
 
-iface.initializationCompleted.connect(customize)
-
+iface.newProjectCreated.connect(customize)
+iface.projectRead.connect(customize)

--- a/code/pyqgis/startup.py
+++ b/code/pyqgis/startup.py
@@ -4,7 +4,9 @@ from qgis.core import QgsExpressionContextUtils
 def customize():
 	version = QgsExpressionContextUtils.globalScope().variable('qgis_version')
 	title = iface.mainWindow().windowTitle()
-	iface.mainWindow().setWindowTitle(f'{title} | {version}')
+	
+	if version not in title:
+		iface.mainWindow().setWindowTitle(f'{title} | {version}')
 
 
 iface.newProjectCreated.connect(customize)


### PR DESCRIPTION
This PR includes a couple of fixes to the `startup.py` script:

- Allow customized title to be persistent when opening or creating project on the same QGIS instance. 
- Avoid edge case wherein version is appended to title more than once. This issue is triggered when launching QGIS (no project), and then creating a new blank project.